### PR TITLE
Add polymarket reference predictions and market-filtering option

### DIFF
--- a/evo_researcher/benchmark/benchmark.py
+++ b/evo_researcher/benchmark/benchmark.py
@@ -62,7 +62,6 @@ class Benchmarker:
             "Mean info_utility": self._compute_mean_info_utility,
             "Mean cost ($)": self._compute_mean_cost,
             "Mean time (s)": self._compute_mean_time,
-            # b) correlation between confidence and prediction error relative to the reference
         }
         self.metric_fns.update(predefined_metric_fns)
 

--- a/evo_researcher/benchmark/benchmark.py
+++ b/evo_researcher/benchmark/benchmark.py
@@ -15,10 +15,11 @@ from evo_researcher.benchmark.agents import (
 )
 from evo_researcher.benchmark.utils import (
     Market,
+    MarketSource,
     Prediction,
     PredictionsCache,
     get_llm_api_call_cost,
-    get_manifold_markets,
+    get_markets,
 )
 
 
@@ -221,7 +222,7 @@ class Benchmarker:
             markets_summary[f"{model_type} p_yes"] = [
                 p.p_yes for p in self.predictions[model_type].values()
             ]
-        markets_summary["manifold p_yes"] = [m.p_yes for m in self.markets]
+        markets_summary[f"reference p_yes"] = [m.p_yes for m in self.markets]
         return markets_summary
 
     def generate_markdown_report(self):
@@ -241,10 +242,16 @@ if __name__ == "__main__":
         type=str,
         default="./benchmark_report.md",
     )
+    args.add_argument(
+        "--reference",
+        type=str,
+        choices=[ms.value for ms in MarketSource],
+        default="manifold",
+    )
     args = args.parse_args()
 
     benchmarker = Benchmarker(
-        markets=get_manifold_markets(number=3),
+        markets=get_markets(number=3, source=MarketSource(args.reference)),
         agents=[
             OlasAgent(model="gpt-3.5-turbo"),  # TODO use same models!
             EvoAgent(model="gpt-4-1106-preview"),

--- a/evo_researcher/benchmark/utils.py
+++ b/evo_researcher/benchmark/utils.py
@@ -103,7 +103,7 @@ def get_polymarket_markets(
     if number > 100:
         raise ValueError("Polymarket API only returns 100 markets at a time")
 
-    api_uri = f"https://strapi-matic.poly.market/markets?_limit={number}&active=true&closed=false"
+    api_uri = f"https://strapi-matic.poly.market/markets?_limit={number + len(excluded_questions)}&active=true&closed=false"
     ms_json = requests.get(api_uri).json()
     markets: t.List[Market] = []
     for m_json in ms_json:

--- a/evo_researcher/benchmark/utils.py
+++ b/evo_researcher/benchmark/utils.py
@@ -1,10 +1,20 @@
+from dotenv import load_dotenv
+from enum import Enum
 import os
 import requests
 import typing as t
 from pydantic import BaseModel
+from py_clob_client.constants import POLYGON
+from py_clob_client.client import ClobClient
+
+
+class MarketSource(Enum):
+    MANIFOLD = "manifold"
+    POLYMARKET = "polymarket"
 
 
 class Market(BaseModel):
+    source: MarketSource
     question: str
     url: str
     p_yes: float
@@ -66,6 +76,7 @@ def get_manifold_markets(number: int = 100) -> t.List[Market]:
 
     response.raise_for_status()
     markets_json = response.json()
+    markets_json["source"] = MarketSource.MANIFOLD
 
     # Map JSON fields to Market fields
     fields_map = {
@@ -80,6 +91,56 @@ def get_manifold_markets(number: int = 100) -> t.List[Market]:
     markets = [m for m in markets if not m.is_resolved]
     assert len(markets) == number
     return markets
+
+
+def get_polymarket_pkey():
+    load_dotenv()
+    pk = os.getenv("POLYMARKET_PKEY")
+    if pk is None:
+        raise ValueError("POLYMARKET_PKEY env var not set")
+    return pk
+
+
+def get_polymarket_client():
+    host = "https://clob.polymarket.com"
+    chain_id = POLYGON
+    client = ClobClient(host, key=get_polymarket_pkey(), chain_id=chain_id)
+    client.set_api_creds(client.create_or_derive_api_creds())
+    return client
+
+
+def get_polymarket_markets(number: int = 100) -> t.List[Market]:
+    if number > 100:
+        raise ValueError("Polymarket API only returns 100 markets at a time")
+
+    client = get_polymarket_client()
+    ms_json = client.get_markets()["data"]
+    markets: t.List[Market] = []
+    for m_json in ms_json:
+        if m_json["closed"]:
+            continue
+        yes_token = [t for t in m_json["tokens"] if t["outcome"] == "Yes"][0]
+        p_yes = client.get_midpoint(yes_token["token_id"])["mid"]
+        markets.append(
+            Market(
+                question=m_json["question"],
+                url=f"https://polymarket.com/event/{m_json['market_slug']}",
+                p_yes=p_yes,
+                volume=0,
+                is_resolved=False,
+                source=MarketSource.POLYMARKET,
+            )
+        )
+    return markets[:number]
+
+
+def get_markets(number: int, source: MarketSource) -> t.List[Market]:
+    if source == MarketSource.MANIFOLD:
+        return get_manifold_markets(number=number)
+    elif source == MarketSource.POLYMARKET:
+        return get_polymarket_markets(number=number)
+    else:
+        raise ValueError(f"Unknown market source: {source}")
 
 
 def get_llm_api_call_cost(model: str, prompt_tokens: int, completion_tokens) -> float:


### PR DESCRIPTION
Currently markets can only be retrieved from manifold to use for reference vs. the evo/olas predictions.

This adds the ability to choose between manifold and polywrap reference markets. The motivation for this is that since betting on polywrap is with real money, you get fewer esoteric markets that are hard to predict and add noise to the benchmark results